### PR TITLE
rgw: fix bug http://tracker.ceph.com/issues/39368

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -949,6 +949,25 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
       int ret = cls_cxx_map_set_val(hctx, idx, &new_key_bl);
       if (ret < 0)
 	return ret;
+
+      string instance_list_idx;
+      struct rgw_bucket_dir_entry instance_list_entry;
+      get_list_index_key(entry, &instance_list_idx);
+      int ret_tmp = read_index_entry(hctx, instance_list_idx, &instance_list_entry);
+      if (ret_tmp == -ENOENT) {
+      } else if (ret_tmp < 0) {
+      } else {
+        int flags_tmp = instance_list_entry.flags;
+        instance_list_entry = entry;
+        instance_list_entry.flags = flags_tmp;
+        bufferlist instance_list_key_bl;
+        ::encode(instance_list_entry, instance_list_key_bl)
+        ret_tmp = cls_cxx_map_set_val(hctx, instance_list_idx, &instance_list_key_bl);
+        if (ret_tmp < 0) {
+          return ret_tmp;
+        }
+      }
+
     }
     break;
   }


### PR DESCRIPTION
rgw: When using versioning, "call Rados::set_attrs for a version (for example, set self-defined metadata)" resulting in inconsistency between [BI_BUCKET_OBJS_INDEX: entry.meta.mtime] and [BI_BUCKET_OBJ_INSTANCE_INDEX: entry.meta.mtime], [DATA : mtime].(The current version cannot be correctly deleted in the lifecycle function)

related questions: ceph#17400


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

