### PR TITLE
rgw: fix Metadata search is not available when using tenants

### DIFF
--- a/src/rgw/rgw_sync_module_es_rest.cc
+++ b/src/rgw/rgw_sync_module_es_rest.cc
@@ -166,7 +166,7 @@ void RGWMetadataSearchOp::execute()
   list<pair<string, string> > conds;
 
   if (!s->user->system) {
-    conds.push_back(make_pair("permissions", s->user->user_id.to_str()));
+    conds.push_back(make_pair("permissions.keyword", s->user->user_id.to_str()));
   }
 
   if (!s->bucket_name.empty()) {
@@ -195,7 +195,7 @@ void RGWMetadataSearchOp::execute()
   static map<string, ESEntityTypeMap::EntityType> generic_map = { {"bucket", ESEntityTypeMap::ES_ENTITY_STR},
                                                            {"name", ESEntityTypeMap::ES_ENTITY_STR},
                                                            {"instance", ESEntityTypeMap::ES_ENTITY_STR},
-                                                           {"permissions", ESEntityTypeMap::ES_ENTITY_STR},
+                                                           {"permissions.keyword", ESEntityTypeMap::ES_ENTITY_STR},
                                                            {"meta.etag", ESEntityTypeMap::ES_ENTITY_STR},
                                                            {"meta.content_type", ESEntityTypeMap::ES_ENTITY_STR},
                                                            {"meta.mtime", ESEntityTypeMap::ES_ENTITY_DATE},
@@ -204,7 +204,7 @@ void RGWMetadataSearchOp::execute()
   ESEntityTypeMap gm(generic_map);
   es_query.set_generic_type_map(&gm);
 
-  static set<string> restricted_fields = { {"permissions"} };
+  static set<string> restricted_fields = { {"permissions.keyword"} };
   es_query.set_restricted_fields(&restricted_fields);
 
   map<string, ESEntityTypeMap::EntityType> custom_map;


### PR DESCRIPTION
tenant$uid: xxcs$test

permissions: xxcs$test
a.Elasticsearch PUT OBJECT: (permissions: xxcs)->OBJECT; (permissions: test)->OBJECT; (permissions.keyword: xxcs$test) -> OBJECT
b.Elasticsearch Query: (permissions == xxcs$test) can not -> OBJECT; (permissions.keyword == xxcs$test) can -> OBJECT


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

